### PR TITLE
Add Technical User Roles connected to Company Profiles

### DIFF
--- a/developer/03. User Management/03. Technical User/01. Summary.md
+++ b/developer/03. User Management/03. Technical User/01. Summary.md
@@ -20,6 +20,7 @@ CX Member companies can create their technical users on their needs and map them
 
 
 ### Available technical user roles
+Following technical user roles are configured/available as standard technical user roles (in portal db as well as the keycloak config delivered with the release package)
 * Connector User
 * Identity Wallet Management
 * BPDM Management
@@ -27,3 +28,41 @@ CX Member companies can create their technical users on their needs and map them
 * Dataspace Discvoery 
 * App Tech User
 * Service Management
+
+<br>
+
+To ensure that technical user profiles are not randomly available but rather customer need specific, the technical user roles are mapped (similar like user roles) to the respective company roles. With that we can enable that specific technical user roles are only available/assignable for those user groups, which actually need the respective permissions.
+
+<br>
+
+> **_NOTE:_**  The assignment of technical users to company roles is managed via the following tables portal.company_service_accounts and portal.user_role_assigned_collections
+
+<br>
+
+The table below gives an overview of the technical user role mapping to the respetcive company roles
+
+Technical User Profile | Assigned Company Role(s) 
+--- | --- 
+App Tech User | App Provider 
+BPDM Management | Operator 
+BPDM Partner Gate | Operator
+BPDM Pool | All
+Connector User | All
+Dataspace Discovery | All
+Identity Wallet Management | All
+Registration External | Operator
+Service Management | Service Provider
+
+<br>
+
+> **_NOTE:_**  Example: if the users company has the role "App Provider" technical users with permissions for
+> * App Tech User
+> * BPDM Pool
+> * Connector User
+> * Dataspace Discovery
+> * Identity Wallet Management
+> are available / can get created, the other technical user permissions are blocked.
+
+<br>
+<br>
+

--- a/docs/03. User Management/01. User Account/index.md
+++ b/docs/03. User Management/01. User Account/index.md
@@ -3,7 +3,11 @@
 User accounts are accounts for real persons - your company employees.
 Read more details in the following sections:
 
-- [FAQ](./1%20FAQ.md)
-- [HowTo](./2%20HowTo.md)
-- [Implementation](./3%20Implementation.md)
-- [Summary](./4%20Summary.md)
+- [Summary](./01.%20Summary.md)
+- [User Account Details](./02.%20User%20Account.md)
+- [Create new user account (single)](./03.%20Create%20new%20user%20account%20(single).md)
+- [Create new user accounts (bulk)](./04.%20Create%20new%20user%20account%20(bulk).md)
+- [FAQ](./05.%20FAQ.md)
+
+<br>
+<br>

--- a/docs/03. User Management/03. Technical User/02. Create Technical User.md
+++ b/docs/03. User Management/03. Technical User/02. Create Technical User.md
@@ -18,6 +18,19 @@ In the Catena-X dataspace, following technical users are provided to all members
 <br>
 <br>
 
+> #### Note
+> depending on the user assigned company roles, not all technical user roles might ba available for technical user creations.
+> The table below shows available technical user roles based on the company role
+>
+> Company Role | Technical User Profile
+> --- | --- 
+> CX Participant | * BPDM Pool<br>* Connector User<br>* Dataspace Discovery<br>* Identity Wallet Management
+> App Provider | * BPDM Pool<br>* Connector User<br>* Dataspace Discovery<br>* Identity Wallet Management<br>* App Tech User
+> Service Provider | * BPDM Pool<br>* Connector User<br>* Dataspace Discovery<br>* Identity Wallet Management<br>* Service Management
+
+<br>
+<br>
+
 ## Create a new technical user
 
 User with the respective user management rights can access the user management via the top right user navigation.

--- a/docs/03. User Management/03. Technical User/index.md
+++ b/docs/03. User Management/03. Technical User/index.md
@@ -7,12 +7,9 @@ CX Member companies can create technical users on their need(s) and map them to 
 <br>
 
 ### Customer Functionalities covered in the function
-* Create new technical user under my org
-* View all my technical users (including technical user details)
-* Delete a technical user
+* Create new technical user under my org - [Details to "How to create a technical user"](../02.%20Create%20Technical%20User.md)
+* View all my technical users (including technical user details) - [Details to "View Technical User Details"](../01.%20Technical%20User%20Overview.md)
+* Delete a technical user - [Details to "How to delete a technical user"](../03.%20Delete%20Technical%20User.md)
 
-<br>
-<br>
-<img width="1361" alt="image" src="https://user-images.githubusercontent.com/94133633/210963262-76d5e1c6-5076-4087-9816-0bd0ed11655a.png">
 <br>
 <br>

--- a/docs/03. User Management/03. Technical User/index.md
+++ b/docs/03. User Management/03. Technical User/index.md
@@ -7,9 +7,9 @@ CX Member companies can create technical users on their need(s) and map them to 
 <br>
 
 ### Customer Functionalities covered in the function
-* Create new technical user under my org - [Details to "How to create a technical user"](/02.%20Create%20Technical%20User.md)
-* View all my technical users (including technical user details) - [Details to "View Technical User Details"](/01.%20Technical%20User%20Overview.md)
-* Delete a technical user - [Details to "How to delete a technical user"](/03.%20Delete%20Technical%20User.md)
+* Create new technical user under my org - [Details to "How to create a technical user"](./02.%20Create%20Technical%20User.md)
+* View all my technical users (including technical user details) - [Details to "View Technical User Details"](./01.%20Technical%20User%20Overview.md)
+* Delete a technical user - [Details to "How to delete a technical user"](./03.%20Delete%20Technical%20User.md)
 
 <br>
 <br>

--- a/docs/03. User Management/03. Technical User/index.md
+++ b/docs/03. User Management/03. Technical User/index.md
@@ -7,9 +7,9 @@ CX Member companies can create technical users on their need(s) and map them to 
 <br>
 
 ### Customer Functionalities covered in the function
-* Create new technical user under my org - [Details to "How to create a technical user"](../02.%20Create%20Technical%20User.md)
-* View all my technical users (including technical user details) - [Details to "View Technical User Details"](../01.%20Technical%20User%20Overview.md)
-* Delete a technical user - [Details to "How to delete a technical user"](../03.%20Delete%20Technical%20User.md)
+* Create new technical user under my org - [Details to "How to create a technical user"](/02.%20Create%20Technical%20User.md)
+* View all my technical users (including technical user details) - [Details to "View Technical User Details"](/01.%20Technical%20User%20Overview.md)
+* Delete a technical user - [Details to "How to delete a technical user"](/03.%20Delete%20Technical%20User.md)
 
 <br>
 <br>


### PR DESCRIPTION
Technical User roles got connected with company roles to enable the portal to manage which technical user roles can get created by which participant based on the participant company role.