### PR TITLE
connector_registration_enable technical user linkage

### DIFF
--- a/developer/02. Technical Integration/01. Connector Registration/03. Create new Connector Registration.md
+++ b/developer/02. Technical Integration/01. Connector Registration/03. Create new Connector Registration.md
@@ -140,7 +140,7 @@ Technical explanation: if the connector.daps_registration_successful is "true" a
 #### API Details
 
 ```diff
-! POST /api/administration/connectors
+! POST /api/administration/connectors/daps
 ```
 
 <br>
@@ -151,8 +151,13 @@ Request Body
       "name": "string",
       "connectorUrl": "string",
       "location": "string",
-      "certificate": "string"
+      "certificate": "string",
+      "technicalUserId": "uuid",
     }
+
+> **_NOTE:_**  Connector certificate is the cert file holding the public key. Details regarding the certificate file creation can get found [here](/docs/02.%20Technical%20Integration/01.%20Connector%20Registration/07.%20FAQ.md#whats-a-public-key-and-how-do-i-create-the-public-key)
+
+> **_NOTE:_**  Optionally an technical user id can get provided when creating the connector. With that the technical user connected with the connector is technically linked inside the portal as well. This supports an easier technical user management for consumer as well as provider (db: connector.company_service_account_id). The technical user need to belong to the same company id and the status of the user must be "ACTIVE"
 
 <br>
 <br>
@@ -218,8 +223,15 @@ Request Body
       "connectorUrl": "string",
       "location": "string",
       "providerBpn": "string",
-      "certificate": "string"
+      "certificate": "string",
+      "technicalUserId": "uuid",
     }
+    
+> **_NOTE:_**  ProviderBPN is the BPN of the data provider / data consumer in which name the connector is supposed to act inside the dataspace.
+
+> **_NOTE:_**  Connector certificate is the cert file holding the public key. Details regarding the certificate file creation can get found [here](/docs/02.%20Technical%20Integration/01.%20Connector%20Registration/07.%20FAQ.md#whats-a-public-key-and-how-do-i-create-the-public-key)
+
+> **_NOTE:_**  Optionally an technical user id can get provided when creating the connector. With that the technical user connected with the connector is technically linked inside the portal as well. This supports an easier technical user management for consumer as well as provider (db: connector.company_service_account_id). The technical user need to belong to the company ID of the providerBPN and the status of the user must be "ACTIVE".
 
 <br>
 <br>


### PR DESCRIPTION
In the current implementation, technical users and connectors are not related to each other.

The latest implementation enables the user to connect an available technical user with a new connector registration. (optionally for now)